### PR TITLE
builder

### DIFF
--- a/examples/builder_api_demo.rs
+++ b/examples/builder_api_demo.rs
@@ -1,0 +1,182 @@
+//! Demonstrates the improved builder API features
+use flag_rs::{CommandBuilder, Flag};
+
+fn main() {
+    // Demonstrates all the new builder API improvements
+    let app = CommandBuilder::new("app")
+        .short("Modern CLI app with improved API")
+        .long(
+            "This example showcases the builder API improvements including:\n\
+               - Type-specific flag constructors\n\
+               - Inline flag completions\n\
+               - Bulk flag/subcommand methods\n\
+               - Type-safe context access",
+        )
+        // Bulk flag addition
+        .flags(vec![
+            // Type-specific constructors
+            Flag::bool("verbose")
+                .short('v')
+                .usage("Enable verbose output")
+                .default_bool(false),
+            Flag::bool("quiet").short('q').usage("Suppress all output"),
+            Flag::int("threads")
+                .short('t')
+                .usage("Number of worker threads")
+                .default_int(4),
+            Flag::choice("log-level", &["debug", "info", "warn", "error"])
+                .usage("Set the logging level")
+                .default_str("info")
+                .completion(|_ctx, prefix| {
+                    // Inline completion with descriptions
+                    let levels = vec![
+                        ("debug", "Show all messages including debug"),
+                        ("info", "Show informational messages and above"),
+                        ("warn", "Show warnings and errors only"),
+                        ("error", "Show errors only"),
+                    ];
+
+                    let mut result = flag_rs::CompletionResult::new();
+                    for (level, desc) in levels {
+                        if level.starts_with(prefix) {
+                            result =
+                                result.add_with_description(level.to_string(), desc.to_string());
+                        }
+                    }
+                    Ok(result)
+                }),
+        ])
+        // Bulk subcommand addition
+        .subcommands(vec![
+            CommandBuilder::new("init")
+                .short("Initialize a new project")
+                .flags(vec![
+                    Flag::string("name")
+                        .short('n')
+                        .usage("Project name")
+                        .required(),
+                    Flag::choice("template", &["basic", "web", "api", "full"])
+                        .usage("Project template to use")
+                        .default_str("basic"),
+                    Flag::directory("path")
+                        .short('p')
+                        .usage("Directory to create project in")
+                        .completion(|_ctx, prefix| {
+                            // In a real app, list actual directories
+                            let dirs = vec!["./", "../", "/tmp/", "~/projects/"];
+                            Ok(flag_rs::CompletionResult::new().extend(
+                                dirs.into_iter()
+                                    .filter(|d| d.starts_with(prefix))
+                                    .map(String::from),
+                            ))
+                        }),
+                ])
+                .run(|ctx| {
+                    // Type-safe flag access
+                    let name = ctx.flag_str_or("name", "my-project");
+                    let template = ctx.flag_str_or("template", "basic");
+                    let path = ctx.flag_str_or("path", ".");
+                    let verbose = ctx.flag_bool_or("verbose", false);
+
+                    if verbose {
+                        println!("Initializing {} project '{}' in {}", template, name, path);
+                    } else {
+                        println!("Creating project '{}'...", name);
+                    }
+
+                    Ok(())
+                })
+                .build(),
+            CommandBuilder::new("build")
+                .short("Build the project")
+                .flags(vec![
+                    Flag::bool("release")
+                        .short('r')
+                        .usage("Build in release mode"),
+                    Flag::string_slice("features")
+                        .short('f')
+                        .usage("Enable features (can be specified multiple times)")
+                        .completion(|_ctx, prefix| {
+                            let features = vec!["async", "tls", "compression", "metrics"];
+                            Ok(flag_rs::CompletionResult::new().extend(
+                                features
+                                    .into_iter()
+                                    .filter(|f| f.starts_with(prefix))
+                                    .map(String::from),
+                            ))
+                        }),
+                    Flag::range("jobs", 1, 32)
+                        .short('j')
+                        .usage("Number of parallel jobs")
+                        .default_int(i64::try_from(num_cpus()).unwrap_or(4)),
+                ])
+                .run(|ctx| {
+                    let release = ctx.flag_bool_or("release", false);
+                    let jobs = ctx.flag_int_or("jobs", i64::try_from(num_cpus()).unwrap_or(4));
+                    let quiet = ctx.flag_bool_or("quiet", false);
+
+                    if !quiet {
+                        println!(
+                            "Building in {} mode with {} jobs",
+                            if release { "release" } else { "debug" },
+                            jobs
+                        );
+
+                        if let Some(features) = ctx.flag("features") {
+                            println!("Features: {}", features);
+                        }
+                    }
+
+                    Ok(())
+                })
+                .build(),
+            CommandBuilder::new("test")
+                .short("Run tests")
+                .flags(vec![
+                    Flag::string("filter").usage("Only run tests matching this pattern"),
+                    Flag::bool("nocapture").usage("Don't capture test output"),
+                    Flag::int("test-threads")
+                        .usage("Number of threads to use for running tests")
+                        .default_int(1),
+                ])
+                .run(|ctx| {
+                    let threads = ctx.flag_int_or("test-threads", 1);
+                    let nocapture = ctx.flag_bool_or("nocapture", false);
+                    let verbose = ctx.flag_bool_or("verbose", false);
+
+                    if verbose {
+                        println!("Running tests with {} thread(s)", threads);
+                        if nocapture {
+                            println!("Output capture disabled");
+                        }
+
+                        if let Some(filter) = ctx.flag("filter") {
+                            println!("Filter: {}", filter);
+                        }
+                    }
+
+                    println!("Running tests...");
+                    Ok(())
+                })
+                .build(),
+        ])
+        .run(|_ctx| {
+            // Root command - show help by default
+            println!("Use --help for usage information");
+            Ok(())
+        })
+        .build();
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if let Err(e) = app.execute(args) {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+}
+
+// Dummy function for example
+fn num_cpus() -> usize {
+    std::thread::available_parallelism()
+        .map(std::num::NonZero::get)
+        .unwrap_or(4)
+}

--- a/examples/flag_completion_demo.rs
+++ b/examples/flag_completion_demo.rs
@@ -1,0 +1,149 @@
+//! Demonstrates inline flag completion support
+use flag_rs::{CommandBuilder, CompletionResult, Flag};
+
+fn main() {
+    let app = CommandBuilder::new("deploy")
+        .short("Deploy application to various environments")
+        .flag(
+            Flag::choice("environment", &["dev", "staging", "prod"])
+                .short('e')
+                .usage("Target environment")
+                .required()
+                .completion(|_ctx, prefix| {
+                    // Dynamic completion - could check available environments
+                    let environments = vec![
+                        ("dev", "Development environment"),
+                        ("staging", "Staging environment (pre-production)"),
+                        ("prod", "Production environment"),
+                    ];
+
+                    let mut result = CompletionResult::new();
+                    for (env, desc) in environments {
+                        if env.starts_with(prefix) {
+                            result = result.add_with_description(env.to_string(), desc.to_string());
+                        }
+                    }
+
+                    // Add active help if no prefix
+                    if prefix.is_empty() {
+                        result = result.add_help_text("Available environments: dev, staging, prod");
+                    }
+
+                    Ok(result)
+                }),
+        )
+        .flag(
+            Flag::file("config")
+                .short('c')
+                .usage("Configuration file")
+                .default_str("config.yaml")
+                .completion(|_ctx, prefix| {
+                    // In a real app, you might list files in the config directory
+                    let configs = vec![
+                        "config.yaml",
+                        "config.dev.yaml",
+                        "config.staging.yaml",
+                        "config.prod.yaml",
+                        "secrets.yaml",
+                    ];
+
+                    Ok(CompletionResult::new().extend(
+                        configs
+                            .into_iter()
+                            .filter(|c| c.starts_with(prefix))
+                            .map(String::from),
+                    ))
+                }),
+        )
+        .flag(
+            Flag::directory("output")
+                .short('o')
+                .usage("Output directory for deployment artifacts")
+                .completion(|_ctx, prefix| {
+                    // In a real app, you might list actual directories
+                    let dirs = vec!["./build", "./dist", "./output", "/tmp/deploy"];
+
+                    Ok(CompletionResult::new().extend(
+                        dirs.into_iter()
+                            .filter(|d| d.starts_with(prefix))
+                            .map(String::from),
+                    ))
+                }),
+        )
+        .flag(
+            Flag::string_slice("service")
+                .short('s')
+                .usage("Services to deploy (can be specified multiple times)")
+                .completion(|ctx, prefix| {
+                    // Context-aware completion based on environment
+                    let env = ctx.flag_str_or("environment", "dev");
+
+                    let services = match env {
+                        "dev" => vec!["api", "web", "worker", "scheduler", "debug-panel"],
+                        "staging" => vec!["api", "web", "worker", "scheduler"],
+                        "prod" => vec!["api", "web", "worker"],
+                        _ => vec!["api", "web"],
+                    };
+
+                    let mut result = CompletionResult::new().extend(
+                        services
+                            .into_iter()
+                            .filter(|s| s.starts_with(prefix))
+                            .map(String::from),
+                    );
+
+                    // Add context-aware help
+                    if prefix.is_empty() {
+                        result = result
+                            .add_help_text(format!("Available services for {} environment", env));
+                    }
+
+                    Ok(result)
+                }),
+        )
+        .flag(
+            Flag::range("replicas", 1, 10)
+                .short('r')
+                .usage("Number of replicas to deploy")
+                .default_int(2)
+                .completion(|_ctx, _prefix| {
+                    // Suggest common replica counts
+                    Ok(CompletionResult::new()
+                        .add_with_description(
+                            "1".to_string(),
+                            "Single instance (dev/test)".to_string(),
+                        )
+                        .add_with_description("2".to_string(), "Basic redundancy".to_string())
+                        .add_with_description("3".to_string(), "Standard production".to_string())
+                        .add_with_description("5".to_string(), "High availability".to_string()))
+                }),
+        )
+        .run(|ctx| {
+            let env = ctx.flag_str_or("environment", "dev");
+            let config = ctx.flag_str_or("config", "config.yaml");
+            let replicas = ctx.flag_int_or("replicas", 2);
+
+            println!("Deploying to {} environment", env);
+            println!("Using configuration: {}", config);
+            println!("Replica count: {}", replicas);
+
+            if let Some(output) = ctx.flag("output") {
+                println!("Output directory: {}", output);
+            }
+
+            if let Some(services) = ctx.flag("service") {
+                println!("Deploying services: {}", services);
+            } else {
+                println!("Deploying all services");
+            }
+
+            Ok(())
+        })
+        .build();
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if let Err(e) = app.execute(args) {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -116,6 +116,180 @@ impl Context {
         &self.flags
     }
 
+    /// Gets a flag value as a boolean
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the flag
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(bool)` if the flag exists and can be parsed as a boolean, `None` otherwise
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use flag_rs::context::Context;
+    ///
+    /// let mut ctx = Context::new(vec![]);
+    /// ctx.set_flag("verbose".to_string(), "true".to_string());
+    /// ctx.set_flag("debug".to_string(), "false".to_string());
+    ///
+    /// assert_eq!(ctx.flag_bool("verbose"), Some(true));
+    /// assert_eq!(ctx.flag_bool("debug"), Some(false));
+    /// assert_eq!(ctx.flag_bool("missing"), None);
+    /// ```
+    pub fn flag_bool(&self, name: &str) -> Option<bool> {
+        self.flag(name)
+            .and_then(|v| match v.to_lowercase().as_str() {
+                "true" | "t" | "1" | "yes" | "y" => Some(true),
+                "false" | "f" | "0" | "no" | "n" => Some(false),
+                _ => None,
+            })
+    }
+
+    /// Gets a flag value as an integer
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the flag
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(i64)` if the flag exists and can be parsed as an integer, `None` otherwise
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use flag_rs::context::Context;
+    ///
+    /// let mut ctx = Context::new(vec![]);
+    /// ctx.set_flag("port".to_string(), "8080".to_string());
+    ///
+    /// assert_eq!(ctx.flag_int("port"), Some(8080));
+    /// assert_eq!(ctx.flag_int("missing"), None);
+    /// ```
+    pub fn flag_int(&self, name: &str) -> Option<i64> {
+        self.flag(name).and_then(|v| v.parse().ok())
+    }
+
+    /// Gets a flag value as a float
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the flag
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(f64)` if the flag exists and can be parsed as a float, `None` otherwise
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use flag_rs::context::Context;
+    ///
+    /// let mut ctx = Context::new(vec![]);
+    /// ctx.set_flag("ratio".to_string(), "0.75".to_string());
+    ///
+    /// assert_eq!(ctx.flag_float("ratio"), Some(0.75));
+    /// assert_eq!(ctx.flag_float("missing"), None);
+    /// ```
+    pub fn flag_float(&self, name: &str) -> Option<f64> {
+        self.flag(name).and_then(|v| v.parse().ok())
+    }
+
+    /// Gets a flag value as a string, returning a default if not present
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the flag
+    /// * `default` - The default value to return if the flag is not set
+    ///
+    /// # Returns
+    ///
+    /// Returns the flag value if present, or the default value
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use flag_rs::context::Context;
+    ///
+    /// let mut ctx = Context::new(vec![]);
+    /// ctx.set_flag("env".to_string(), "production".to_string());
+    ///
+    /// assert_eq!(ctx.flag_str_or("env", "development"), "production");
+    /// assert_eq!(ctx.flag_str_or("missing", "development"), "development");
+    /// ```
+    pub fn flag_str_or<'a>(&'a self, name: &str, default: &'a str) -> &'a str {
+        self.flag(name).map_or(default, String::as_str)
+    }
+
+    /// Gets a flag value as a boolean, returning a default if not present
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the flag
+    /// * `default` - The default value to return if the flag is not set or cannot be parsed
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use flag_rs::context::Context;
+    ///
+    /// let mut ctx = Context::new(vec![]);
+    /// ctx.set_flag("verbose".to_string(), "true".to_string());
+    ///
+    /// assert_eq!(ctx.flag_bool_or("verbose", false), true);
+    /// assert_eq!(ctx.flag_bool_or("missing", false), false);
+    /// ```
+    pub fn flag_bool_or(&self, name: &str, default: bool) -> bool {
+        self.flag_bool(name).unwrap_or(default)
+    }
+
+    /// Gets a flag value as an integer, returning a default if not present
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the flag
+    /// * `default` - The default value to return if the flag is not set or cannot be parsed
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use flag_rs::context::Context;
+    ///
+    /// let mut ctx = Context::new(vec![]);
+    /// ctx.set_flag("port".to_string(), "8080".to_string());
+    ///
+    /// assert_eq!(ctx.flag_int_or("port", 3000), 8080);
+    /// assert_eq!(ctx.flag_int_or("missing", 3000), 3000);
+    /// ```
+    pub fn flag_int_or(&self, name: &str, default: i64) -> i64 {
+        self.flag_int(name).unwrap_or(default)
+    }
+
+    /// Gets a flag value as a float, returning a default if not present
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the flag
+    /// * `default` - The default value to return if the flag is not set or cannot be parsed
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use flag_rs::context::Context;
+    ///
+    /// let mut ctx = Context::new(vec![]);
+    /// ctx.set_flag("ratio".to_string(), "0.75".to_string());
+    ///
+    /// assert_eq!(ctx.flag_float_or("ratio", 0.5), 0.75);
+    /// assert_eq!(ctx.flag_float_or("missing", 0.5), 0.5);
+    /// ```
+    pub fn flag_float_or(&self, name: &str, default: f64) -> f64 {
+        self.flag_float(name).unwrap_or(default)
+    }
+
     /// Stores a typed value in the context
     ///
     /// Values are stored by their type, so only one value of each type


### PR DESCRIPTION
  1. Type-specific flag constructors (api-1) ✓

  - Added Flag::bool(), Flag::int(), Flag::float(), Flag::string(), Flag::string_slice(), Flag::choice(), Flag::range(), Flag::file(), and
  Flag::directory() methods
  - Added type-specific default setters: default_bool(), default_int(), default_float(), and default_str()

  2. Type-safe flag access methods (api-2) ✓

  - Added to Context: flag_bool(), flag_int(), flag_float(), flag_str_or(), flag_bool_or(), flag_int_or(), and flag_float_or()
  - These provide ergonomic, type-safe access to flag values with automatic parsing

  3. Inline completion support for flags (api-3) ✓

  - Added completion field to Flag struct with custom Clone implementation
  - Added Flag::completion() builder method to attach completion functions directly to flags
  - Modified command completion logic to check flag's own completion function first
  - Created flag_completion_demo.rs example

  4. Bulk flag/subcommand methods (api-4) ✓

  - Added CommandBuilder::flags() to add multiple flags at once
  - Added CommandBuilder::subcommands() to add multiple subcommands at once
  - Makes building complex CLIs more concise

  5. Examples demonstrating improved API (api-5) ✓

  - Created flag_completion_demo.rs - demonstrates inline flag completions
  - Created builder_api_demo.rs - comprehensive example showing all improvements
